### PR TITLE
Allowed html in the item header

### DIFF
--- a/paper-collapse-item.html
+++ b/paper-collapse-item.html
@@ -75,7 +75,7 @@ Custom property | Description | Default
 					<template is="dom-if" if="[[icon]]">
 						<iron-icon class="icon" src="[[src]]" icon="[[icon]]"></iron-icon>
 					</template>
-					<div class="flex">[[header]]</div>
+					<div class="flex" inner-h-t-m-l="[[header]]"></div>
 					<paper-icon-button class="toogle" icon="[[_toggleIcon]]"></paper-icon-button>
 				</div>
 				<iron-collapse class="content" opened="{{opened}}">


### PR DESCRIPTION
Allowed html in the header  , the following now is accepted

``` html
<paper-collapse-item icon="icons:favorite" header="<b>Item 1</b>" opened>
  Lots of very interesting content.
</paper-collapse-item>
```
