### PR TITLE
Allow collapsible content to span on multiple lines

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -13,8 +13,8 @@
 				<paper-collapse-item icon="icons:favorite" header="Item 1" opened>
 					Lots of very interesting content.
 				</paper-collapse-item>
-				<paper-collapse-item icon="icons:info" header="Item 2">
-					Lots of very interesting content.
+				<paper-collapse-item icon="icons:info" header="Item 2 (multiline content)">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque convallis felis fringilla, scelerisque augue eget, finibus sapien. Aliquam erat volutpat. Morbi libero urna, vestibulum sed facilisis id, sodales id lectus. Sed condimentum molestie ligula, sed posuere purus congue vitae. Nulla non augue velit. Aliquam in magna ac leo tincidunt ullamcorper et sit amet erat. Fusce sit amet posuere diam. Nunc scelerisque purus nisi, a faucibus est convallis eget. Donec interdum ullamcorper gravida. In hendrerit iaculis mi consectetur vestibulum. Proin eget tortor est. Proin imperdiet lectus et gravida tincidunt.
 				</paper-collapse-item>
 				<paper-collapse-item icon="icons:help" header="Item 3 (with event)" on-toggle="onToggle">
 					Lots of very interesting content.

--- a/paper-collapse-item.html
+++ b/paper-collapse-item.html
@@ -66,6 +66,7 @@ Custom property | Description | Default
 				color: var(--primary-text-color);
 				@apply(--paper-font-body1);
 				@apply(--paper-collapse-item-content);
+				padding: 0 16px;
 			}
 		</style>
 
@@ -78,11 +79,11 @@ Custom property | Description | Default
 					<div class="flex">[[header]]</div>
 					<paper-icon-button class="toogle" icon="[[_toggleIcon]]"></paper-icon-button>
 				</div>
-				<iron-collapse class="content" opened="{{opened}}">
-					<content></content>
-				</iron-collapse>
 			</paper-item-body>
 		</paper-item>
+		<iron-collapse class="content" opened="{{opened}}">
+			<content></content>
+		</iron-collapse>
 
 	</template>
 </dom-module>


### PR DESCRIPTION
Problem: by default, content inside 'paper-item-body' does not allow text wrapping, preventing people to use this component with multi-line content.

Proposed solution: take the collapsible content out of the paper-item, so that content can span on multiple lines. 
