### PR TITLE
Allow to style the whole element

### DIFF
--- a/paper-collapse-item.html
+++ b/paper-collapse-item.html
@@ -33,7 +33,7 @@ Custom property | Description | Default
 --paper-collapse-item-header|Mixin applied to header of collapsible item|{}
 --paper-collapse-item-content|Mixin applied to collapsible content|{}
 --paper-collapse-item-icon|Mixin applied to icon|{}
-
+--paper-collapse-item-element|Mixin applied to the whole element|{}
 
 @demo demo/index.html
 -->
@@ -67,9 +67,14 @@ Custom property | Description | Default
 				@apply(--paper-font-body1);
 				@apply(--paper-collapse-item-content);
 			}
+
+			.element {
+				@apply(--paper-collapse-item-element);
+			}
+
 		</style>
 
-		<paper-item>
+		<paper-item class="element">
 			<paper-item-body>
 				<div class="header" on-tap="_toggleOpened">
 					<template is="dom-if" if="[[icon]]">


### PR DESCRIPTION
Bofore it was possible to style single parts of the element, but it was
not possible to style the whole element. This is pragmatic for example
for background color, or paddings.
Now the new mixin --paper-collapse-item-element allows to style the whole
element.
