### PR TITLE
Header icon color overlap

### DIFF
--- a/paper-collapse-item.html
+++ b/paper-collapse-item.html
@@ -59,7 +59,7 @@ Custom property | Description | Default
 				@apply --paper-collapse-item-icon;
 			}
 
-			.icon, .toogle {
+			.toogle {
 				color: var(--disabled-text-color);
 			}
 


### PR DESCRIPTION
Prevents overlapping the header icon color.

I was making a schedule type list for an online service, where whenever some is online I should display this icon in green else black. And stumble across the impossibility of setting the iron icon color via mixins, since it is then force to `var(--disabled-text-color)`.