### PR TITLE
Add in rudimentary simple-paper-item based on the pre-polymer3 version.

### DIFF
--- a/paper-collapse-item.js
+++ b/paper-collapse-item.js
@@ -6,6 +6,7 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/paper-item/paper-item.js';
 import '@polymer/paper-item/paper-item-body.js';
 import '@polymer/paper-styles/paper-styles.js';
+import './simple-paper-item.js';
 
 /**
  * `PaperCollapseItem`

--- a/simple-paper-item.js
+++ b/simple-paper-item.js
@@ -1,0 +1,29 @@
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import '@polymer/paper-item/paper-item-shared-styles.js';
+import '@polymer/iron-flex-layout/iron-flex-layout.js';
+
+/*
+    A <paper-item> that avoids problems with <paper-input> children.  See
+href="https://github.com/PolymerElements/paper-item/issues/103  for details.
+
+    */
+
+Polymer({
+    _template: html`
+    <style include="paper-item-shared-styles">
+      :host {
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        @apply --paper-font-subhead;
+        @apply --paper-item;
+      }
+    </style>
+    <slot></slot>
+    `,
+    is: 'simple-paper-item',
+    behavior: [
+        Polymer.IronControlState,
+        Polymer.PaperItemBehaviorImpl
+    ]
+});


### PR DESCRIPTION
Using the polymer modularizer reduced this to just the two behaviours (without the styles), so I've instead duplicated the paper-item element code substituting just the behaviours from the old simple-paper-item.  I haven't tested whether this catches spaces (which seemed to be the need for the element in the first place) and this is the first distribution polymer element I've worked on, so lemme know if I've made any of the imports incorrectly...  5:)

Hopefully this will resolve with issue #35.  It certainly fixes the formatting issues.